### PR TITLE
use contao-console from package directly

### DIFF
--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -78,8 +78,9 @@ class ScriptHandler
 
         $process = new Process(
             sprintf(
-                '%s vendor/bin/contao-console%s %s%s --env=prod',
-                $phpPath,
+                '%s %s%s %s%s --env=prod',
+                escapeshellarg($phpPath),
+                escapeshellarg(__DIR__.'/../../bin/contao-console'),
                 $event->getIO()->isDecorated() ? ' --ansi' : '',
                 $cmd,
                 self::getVerbosityFlag($event)


### PR DESCRIPTION
insteadof composers vender/bin one, because under windows these are
launcher scripts for the package command and not symlinks of it