### PR TITLE
Delete the bundle cache upon cache:clear

### DIFF
--- a/src/Cache/BundleCacheClearer.php
+++ b/src/Cache/BundleCacheClearer.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\ManagerBundle\Cache;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+
+/**
+ * Clears the bundle cache.
+ *
+ * @author Kamil Kuzminski <https://github.com/qzminski>
+ */
+class BundleCacheClearer implements CacheClearerInterface
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * Constructor.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear($cacheDir)
+    {
+        $this->filesystem->remove($cacheDir.'/bundles.map');
+    }
+}

--- a/src/Cache/BundleCacheClearer.php
+++ b/src/Cache/BundleCacheClearer.php
@@ -21,25 +21,11 @@ use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 class BundleCacheClearer implements CacheClearerInterface
 {
     /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * Constructor.
-     *
-     * @param Filesystem $filesystem
-     */
-    public function __construct(Filesystem $filesystem)
-    {
-        $this->filesystem = $filesystem;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function clear($cacheDir)
     {
-        $this->filesystem->remove($cacheDir.'/bundles.map');
+        $filesystem = new Filesystem();
+        $filesystem->remove($cacheDir.'/bundles.map');
     }
 }

--- a/src/Cache/BundleCacheClearer.php
+++ b/src/Cache/BundleCacheClearer.php
@@ -21,11 +21,25 @@ use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 class BundleCacheClearer implements CacheClearerInterface
 {
     /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * Constructor.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem = null)
+    {
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function clear($cacheDir)
     {
-        $filesystem = new Filesystem();
-        $filesystem->remove($cacheDir.'/bundles.map');
+        $this->filesystem->remove($cacheDir.'/bundles.map');
     }
 }

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -29,6 +29,8 @@ class ScriptHandler
      */
     public static function initializeApplication(Event $event)
     {
+        static::purgeCacheFolder();
+
         static::addAppDirectory();
         static::addWebEntryPoints($event);
 
@@ -37,6 +39,15 @@ class ScriptHandler
 
         static::executeCommand('contao:install', $event);
         static::executeCommand('contao:symlinks', $event);
+    }
+
+    /**
+     * Purge the cache folder
+     */
+    public static function purgeCacheFolder()
+    {
+        $filesystem = new Filesystem();
+        $filesystem->removeDirectory(getcwd().'/var/cache/prod');
     }
 
     /**

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,4 +1,12 @@
 services:
+    contao_manager.cache.clear_bundle:
+        class: Contao\ManagerBundle\Cache\BundleCacheClearer
+        public: false
+        arguments:
+            - "@filesystem"
+        tags:
+            - { name: kernel.cache_clearer }
+
     contao_manager.plugin_loader:
         class: Contao\ManagerBundle\ContaoManager\PluginLoader
         synthetic: true

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,8 +2,6 @@ services:
     contao_manager.cache.clear_bundle:
         class: Contao\ManagerBundle\Cache\BundleCacheClearer
         public: false
-        arguments:
-            - "@filesystem"
         tags:
             - { name: kernel.cache_clearer }
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,8 @@ services:
     contao_manager.cache.clear_bundle:
         class: Contao\ManagerBundle\Cache\BundleCacheClearer
         public: false
+        arguments:
+            - "@filesystem"
         tags:
             - { name: kernel.cache_clearer }
 

--- a/tests/Cache/BundleCacheClearerTest.php
+++ b/tests/Cache/BundleCacheClearerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Contao\ManagerBundle\Test\Cache;
+
+use Contao\CoreBundle\Test\TestCase;
+use Contao\ManagerBundle\Cache\BundleCacheClearer;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Tests the BundleCacheClearer class.
+ *
+ * @author Kamil Kuzminski <https://github.com/qzminski>
+ */
+class BundleCacheClearerTest extends TestCase
+{
+    /**
+     * Tests the object instantiation.
+     */
+    public function testInstantiation()
+    {
+        $clearer = new BundleCacheClearer(new Filesystem());
+
+        $this->assertInstanceOf('Contao\ManagerBundle\Cache\BundleCacheClearer', $clearer);
+    }
+
+    /**
+     * Tests the clear() method.
+     */
+    public function testClear()
+    {
+        $fs = new Filesystem();
+        $cacheDir = $this->getCacheDir();
+
+        $fs->touch("$cacheDir/bundles.map");
+        $this->assertFileExists("$cacheDir/bundles.map");
+
+        $clearer = new BundleCacheClearer($fs);
+        $clearer->clear($cacheDir);
+
+        $this->assertFileNotExists("$cacheDir/bundles.map");
+    }
+}

--- a/tests/Cache/BundleCacheClearerTest.php
+++ b/tests/Cache/BundleCacheClearerTest.php
@@ -18,7 +18,7 @@ class BundleCacheClearerTest extends TestCase
      */
     public function testInstantiation()
     {
-        $clearer = new BundleCacheClearer(new Filesystem());
+        $clearer = new BundleCacheClearer();
 
         $this->assertInstanceOf('Contao\ManagerBundle\Cache\BundleCacheClearer', $clearer);
     }


### PR DESCRIPTION
… and before app is initialized after Composer install. Otherwise the container is not bootable if we install an extra bundle (say ```contao/calendar-bundle```) and then remove it from ```composer.json```. Then upon ```composer update``` command the bundle is being removed but its reference still sits in the ```$cacheDir/bundles.map``` and thus causes an error.

With regards to https://github.com/contao/managed-edition/issues/1