### PR TITLE
Disable AppCache for Active Backend Users

### DIFF
--- a/src/Resources/web/app.php
+++ b/src/Resources/web/app.php
@@ -24,11 +24,13 @@ $kernel = new ContaoKernel('prod', false);
 $kernel->setRootDir(dirname(__DIR__).'/app');
 
 // Enable the Symfony reverse proxy
-$kernel = new ContaoCache($kernel);
 Request::enableHttpMethodParameterOverride();
 
 // Handle the request
 $request = Request::createFromGlobals();
+if(!$request->cookies->has('BE_USER_AUTH')){
+	$kernel = new AppCache($kernel);
+}
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);


### PR DESCRIPTION
I had a customer that wanted to see the changes he made straight away. But with the enabled cache, this was not possible.
I talked to Toflar and we came to the solution that it would be a good idea to only enable the AppCache if the user is not logged in to the backend.