### PR TITLE
Added command options to define the dev entry point password

### DIFF
--- a/src/Command/InstallWebDirCommand.php
+++ b/src/Command/InstallWebDirCommand.php
@@ -212,9 +212,9 @@ class InstallWebDirCommand extends AbstractLockedCommand
             throw new \InvalidArgumentException('Must have username and password to set the access key.');
         }
 
-        $accessKey = hash(
-            'sha512',
-            $input->getOption('user').':'.$input->getOption('password')
+        $accessKey = password_hash(
+            $input->getOption('user').':'.$input->getOption('password'),
+            PASSWORD_DEFAULT
         );
 
         $this->addToDotEnv($projectDir, 'APP_DEV_ACCESSKEY', $accessKey);

--- a/src/Command/InstallWebDirCommand.php
+++ b/src/Command/InstallWebDirCommand.php
@@ -11,9 +11,12 @@
 namespace Contao\ManagerBundle\Command;
 
 use Contao\CoreBundle\Command\AbstractLockedCommand;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -45,6 +48,16 @@ class InstallWebDirCommand extends AbstractLockedCommand
     ];
 
     /**
+     * Files that should not be copied on no-dev option.
+     *
+     * @var array
+     */
+    private $devFiles = [
+        'app_dev.php',
+    ];
+
+
+    /**
      * {@inheritdoc}
      */
     protected function configure()
@@ -58,7 +71,61 @@ class InstallWebDirCommand extends AbstractLockedCommand
                 'The installation root directory (defaults to the current working directory).',
                 getcwd()
             )
+            ->addOption(
+                'no-dev',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not copy the app_dev.php entry point to the web folder.'
+            )
+            ->addOption(
+                'user',
+                'u',
+                InputOption::VALUE_REQUIRED,
+                'Username for the app_dev.php entry point.'
+            )
+            ->addOption(
+                'password',
+                'p',
+                InputOption::VALUE_OPTIONAL,
+                'Password for the app_dev.php entry point.'
+            )
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $user = $input->getOption('user');
+        $password = $input->getOption('password');
+
+        if (true === $input->getOption('no-dev') && (null !== $user || null !== $password)) {
+            throw new \InvalidArgumentException('Cannot set a password in no-dev mode!');
+        }
+
+        if (null === $password && null !== $user) {
+            throw new \InvalidArgumentException('Cannot set a username without password.');
+        }
+
+        if (true !== $password) {
+            return;
+        }
+
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+
+        if (null === $input->getOption('user')) {
+            $input->setOption(
+                'user',
+                $helper->ask($input, $output, new Question('Please enter a username:'))
+            );
+        }
+
+        $input->setOption(
+            'password',
+            $helper->ask($input, $output, (new Question('Please enter a password:'))->setHidden(true))
+        );
     }
 
     /**
@@ -69,11 +136,12 @@ class InstallWebDirCommand extends AbstractLockedCommand
         $this->fs = new Filesystem();
         $this->io = new SymfonyStyle($input, $output);
 
-        $baseDir = $input->getArgument('path');
-        $webDir = rtrim($baseDir, '/').'/web';
+        $projectDir = $input->getArgument('path');
+        $webDir = rtrim($projectDir, '/').'/web';
 
-        $this->addFiles($webDir);
+        $this->addFiles($webDir, !$input->getOption('no-dev'));
         $this->removeInstallPhp($webDir);
+        $this->storeAppDevAccesskey($input, $projectDir);
 
         return 0;
     }
@@ -82,8 +150,9 @@ class InstallWebDirCommand extends AbstractLockedCommand
      * Adds files from Resources/web to the application's web directory.
      *
      * @param string $webDir
+     * @param bool   $dev
      */
-    private function addFiles($webDir)
+    private function addFiles($webDir, $dev = true)
     {
         /** @var Finder $finder */
         $finder = Finder::create()->files()->ignoreDotFiles(false)->in(__DIR__.'/../Resources/web');
@@ -92,6 +161,10 @@ class InstallWebDirCommand extends AbstractLockedCommand
             if (in_array($file->getRelativePathname(), $this->optionalFiles, true)
                 && $this->fs->exists($webDir.'/'.$file->getRelativePathname())
             ) {
+                continue;
+            }
+
+            if (!$dev && in_array($file->getRelativePathname(), $this->devFiles, true)) {
                 continue;
             }
 
@@ -108,8 +181,75 @@ class InstallWebDirCommand extends AbstractLockedCommand
      */
     private function removeInstallPhp($webDir)
     {
-        if (file_exists($webDir.'/install.php')) {
-            $this->fs->remove($webDir.'/install.php');
+        if (!file_exists($webDir.'/install.php')) {
+            return;
         }
+
+        $this->fs->remove($webDir.'/install.php');
+        $this->io->text('Deleted the <comment>web/install.php</comment> file.');
+    }
+
+    /**
+     * Stores username and password in .env file in the project directory.
+     *
+     * @param InputInterface $input
+     * @param string         $projectDir
+     */
+    private function storeAppDevAccesskey(InputInterface $input, $projectDir)
+    {
+        $user = $input->getOption('user');
+        $password = $input->getOption('password');
+
+        if (null === $password && null === $user) {
+            return;
+        }
+
+        if (true === $input->getOption('no-dev') && (null !== $user || null !== $password)) {
+            throw new \InvalidArgumentException('Cannot set a password in no-dev mode!');
+        }
+
+        if ((null === $password && null !== $user) || (null === $user && null !== $password)) {
+            throw new \InvalidArgumentException('Must have username and password to set the access key.');
+        }
+
+        $accessKey = hash(
+            'sha512',
+            $input->getOption('user').':'.$input->getOption('password')
+        );
+
+        $this->addToDotEnv($projectDir, 'APP_DEV_ACCESSKEY', $accessKey);
+    }
+
+    /**
+     * Appends value to the .env file, removing a line with the given key.
+     *
+     * @param string $projectDir
+     * @param string $key
+     * @param string $value
+     */
+    private function addToDotEnv($projectDir, $key, $value)
+    {
+        $fs = new Filesystem();
+
+        $path = $projectDir.'/.env';
+        $content = '';
+
+        if ($fs->exists($path)) {
+            $lines = file($path, FILE_IGNORE_NEW_LINES);
+
+            if (false === $lines) {
+                throw new \RuntimeException(sprintf('Could not read "%s" file.', $path));
+            }
+
+            foreach ($lines as $line) {
+                if (0 === strpos($line, $key.'=')) {
+                    continue;
+                }
+
+                $content .= $line."\n";
+            }
+        }
+
+        $fs->dumpFile($path, $content.$key.'='.$value."\n");
     }
 }

--- a/src/Command/InstallWebDirCommand.php
+++ b/src/Command/InstallWebDirCommand.php
@@ -250,6 +250,6 @@ class InstallWebDirCommand extends AbstractLockedCommand
             }
         }
 
-        $fs->dumpFile($path, $content.$key.'='.$value."\n");
+        $fs->dumpFile($path, $content.$key.'='.escapeshellarg($value)."\n");
     }
 }

--- a/src/Resources/web/app_dev.php
+++ b/src/Resources/web/app_dev.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+use Contao\ManagerBundle\ContaoManager\Plugin as ManagerBundlePlugin;
+use Contao\ManagerBundle\HttpKernel\ContaoKernel;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Symfony\Component\Debug\Debug;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\HttpFoundation\Request;
+
+// The check is to ensure we don't use .env in production
+if (file_exists(__DIR__.'/../.env')) {
+    (new Dotenv())->load(__DIR__.'/../.env');
+}
+
+// Access to debug front controllers is only allowed on localhost or with authentication.
+// Use the "contao:install-web-dir" console command to set a password for the dev entry point.
+$accessKey = getenv('APP_DEV_ACCESSKEY', true);
+
+if (isset($_SERVER['HTTP_CLIENT_IP'])
+    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', 'fe80::1', '::1']) || php_sapi_name() === 'cli-server')
+) {
+    if (false === $accessKey) {
+        header('HTTP/1.0 403 Forbidden');
+        die(sprintf('You are not allowed to access this file. Check %s for more information.', basename(__FILE__)));
+    }
+
+    if (!isset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])
+        || hash('sha512', $_SERVER['PHP_AUTH_USER'].':'.$_SERVER['PHP_AUTH_PW']) !== $accessKey
+    ) {
+        header('WWW-Authenticate: Basic realm="Contao debug"');
+        header('HTTP/1.0 401 Unauthorized');
+        die(sprintf('You are not allowed to access this file. Check %s for more information.', basename(__FILE__)));
+    }
+}
+
+unset($accessKey);
+
+/** @var Composer\Autoload\ClassLoader */
+$loader = require __DIR__.'/../vendor/autoload.php';
+
+Debug::enable();
+AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+ManagerBundlePlugin::autoloadModules(__DIR__.'/../system/modules');
+
+ContaoKernel::setProjectDir(dirname(__DIR__));
+$kernel = new ContaoKernel('dev', true);
+
+Request::enableHttpMethodParameterOverride();
+
+// Handle the request
+$request = Request::createFromGlobals();
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);

--- a/src/Resources/web/app_dev.php
+++ b/src/Resources/web/app_dev.php
@@ -15,13 +15,16 @@ use Symfony\Component\Debug\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 
-// The check is to ensure we don't use .env in production
+/***********************************************************************************************/
+/*                               ###  READ FIRST  ###                                          */
+/* Access to debug front controllers must only be allowed on localhost or with authentication. */
+/* Use the "contao:install-web-dir" console command to set a password for the dev entry point. */
+/***********************************************************************************************/
+
 if (file_exists(__DIR__.'/../.env')) {
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 
-// Access to debug front controllers is only allowed on localhost or with authentication.
-// Use the "contao:install-web-dir" console command to set a password for the dev entry point.
 $accessKey = getenv('APP_DEV_ACCESSKEY', true);
 
 if (isset($_SERVER['HTTP_CLIENT_IP'])
@@ -34,7 +37,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     }
 
     if (!isset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])
-        || hash('sha512', $_SERVER['PHP_AUTH_USER'].':'.$_SERVER['PHP_AUTH_PW']) !== $accessKey
+        || !password_verify($_SERVER['PHP_AUTH_USER'].':'.$_SERVER['PHP_AUTH_PW'], $accessKey)
     ) {
         header('WWW-Authenticate: Basic realm="Contao debug"');
         header('HTTP/1.0 401 Unauthorized');


### PR DESCRIPTION
fixes https://github.com/contao/manager-bundle/issues/23

Symfony 3.3 introduced the .env component (http://symfony.com/blog/new-in-symfony-3-3-dotenv-component). The app_dev.php password is always stored there, which has multiple advantages:
 1. @discordier can always use that variable as requested in #23 
 2. the file is persistent across multiple `composer:update` commands (that will re-run `contao:install-web-dir` and would delete the password
 3. The .env file can be deployed to dev but not to prod