### PR TITLE
Ignore warning for second parameter in getenv()

### DIFF
--- a/src/Resources/web/app_dev.php
+++ b/src/Resources/web/app_dev.php
@@ -27,7 +27,7 @@ if (file_exists(__DIR__.'/../.env')) {
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 
-$accessKey = getenv('APP_DEV_ACCESSKEY', true);
+$accessKey = @getenv('APP_DEV_ACCESSKEY', true);
 
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])


### PR DESCRIPTION
`getenv()` does not support the second parameter in all supported PHP versions. This results in *“Warning: getenv() expects exactly 1 parameter, 2 given”*. I think we should ignore this warning in the *app_dev.php* entry point.