### PR TITLE
[RFC] fix interaction of contao:install-web-dir

### DIFF
--- a/src/Command/InstallWebDirCommand.php
+++ b/src/Command/InstallWebDirCommand.php
@@ -96,18 +96,7 @@ class InstallWebDirCommand extends AbstractLockedCommand
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $user = $input->getOption('user');
-        $password = $input->getOption('password');
-
-        if (true === $input->getOption('no-dev') && (null !== $user || null !== $password)) {
-            throw new \InvalidArgumentException('Cannot set a password in no-dev mode!');
-        }
-
-        if (null === $password && null !== $user) {
-            throw new \InvalidArgumentException('Cannot set a username without password.');
-        }
-
-        if (true !== $password) {
+        if (true === $input->getOption('no-dev')) {
             return;
         }
 
@@ -125,6 +114,17 @@ class InstallWebDirCommand extends AbstractLockedCommand
             'password',
             $helper->ask($input, $output, (new Question('Please enter a password:'))->setHidden(true))
         );
+
+        $user = $input->getOption('user');
+        $password = $input->getOption('password');
+
+        if (true === $input->getOption('no-dev') && (null !== $user || null !== $password)) {
+            throw new \InvalidArgumentException('Cannot set a password in no-dev mode!');
+        }
+
+        if (null === $password && null !== $user) {
+            throw new \InvalidArgumentException('Cannot set a username without password.');
+        }
     }
 
     /**

--- a/src/Command/InstallWebDirCommand.php
+++ b/src/Command/InstallWebDirCommand.php
@@ -118,10 +118,6 @@ class InstallWebDirCommand extends AbstractLockedCommand
         $user = $input->getOption('user');
         $password = $input->getOption('password');
 
-        if (true === $input->getOption('no-dev') && (null !== $user || null !== $password)) {
-            throw new \InvalidArgumentException('Cannot set a password in no-dev mode!');
-        }
-
         if (null === $password && null !== $user) {
             throw new \InvalidArgumentException('Cannot set a username without password.');
         }

--- a/src/Command/InstallWebDirCommand.php
+++ b/src/Command/InstallWebDirCommand.php
@@ -110,10 +110,12 @@ class InstallWebDirCommand extends AbstractLockedCommand
             );
         }
 
-        $input->setOption(
-            'password',
-            $helper->ask($input, $output, (new Question('Please enter a password:'))->setHidden(true))
-        );
+        if (null === $input->getOption('password')) {
+            $input->setOption(
+                'password',
+                $helper->ask($input, $output, (new Question('Please enter a password:'))->setHidden(true))
+            );
+        }
 
         $user = $input->getOption('user');
         $password = $input->getOption('password');


### PR DESCRIPTION
This fixes #39 and #40. With this change, the command will always ask for the username and password (if not defined with `--user=…` or `--password=…`) for the dev entry point - unless the `--no-dev` argument was provided.