### PR TITLE
Add error when cli args aren't set properly

### DIFF
--- a/bin/contao-console
+++ b/bin/contao-console
@@ -38,7 +38,12 @@ if ($debug) {
     Debug::enable();
 }
 
-ContaoKernel::setProjectDir($projectDir);
-$kernel = new ContaoKernel($env, $debug);
-$application = new Application($kernel);
-$application->run($input);
+if(!$_SERVER['argv']) {
+	print "No arguments are set. Please make sure that 'register_argc_argv' in your php.ini is set to 'On'\n";
+}
+else {
+	ContaoKernel::setProjectDir($projectDir);
+	$kernel = new ContaoKernel($env, $debug);
+	$application = new Application($kernel);
+	$application->run($input);
+}


### PR DESCRIPTION
Some providers set the php.ini argument register_argc_argv to 'Off'. This results in the contao-console command always showing the help page. A small error message when the $argsv / $argsc variables aren't set helps to solve this problem much faster. When register_argc_argv is set to 'On' no arguments still means that the variables are set so the help page is shown properly.