### PR TITLE
[WIP] Activate ORM by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "4.5.x-dev"
+            "dev-4.5": "4.5.x-dev"
         },
         "contao-manager-plugin": "Contao\\ManagerBundle\\ContaoManager\\Plugin"
     },

--- a/src/Api/Application.php
+++ b/src/Api/Application.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Api;
 
+use Contao\ManagerBundle\Api\Command\GetAccesskeyCommand;
+use Contao\ManagerBundle\Api\Command\RemoveAccesskeyCommand;
+use Contao\ManagerBundle\Api\Command\SetAccesskeyCommand;
 use Contao\ManagerBundle\Api\Command\GetConfigCommand;
 use Contao\ManagerBundle\Api\Command\SetConfigCommand;
 use Contao\ManagerBundle\Api\Command\VersionCommand;
@@ -98,8 +101,11 @@ class Application extends BaseApplication
         $commands = parent::getDefaultCommands();
 
         $commands[] = new VersionCommand();
-        $commands[] = new GetConfigCommand();
-        $commands[] = new SetConfigCommand();
+        $commands[] = new GetConfigCommand($this->getManagerConfig());
+        $commands[] = new SetConfigCommand($this->getManagerConfig());
+        $commands[] = new GetAccesskeyCommand($this->projectDir);
+        $commands[] = new SetAccesskeyCommand($this->projectDir);
+        $commands[] = new RemoveAccesskeyCommand($this->projectDir);
 
         return $commands;
     }

--- a/src/Api/Command/GetAccesskeyCommand.php
+++ b/src/Api/Command/GetAccesskeyCommand.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Contao.
  *
@@ -12,26 +10,26 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Api\Command;
 
-use Contao\ManagerBundle\Api\ManagerConfig;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Dotenv\Dotenv;
 
-class GetConfigCommand extends Command
+class GetAccesskeyCommand extends Command
 {
     /**
-     * @var ManagerConfig
+     * @var string
      */
-    private $managerConfig;
+    private $projectDir;
 
     /**
-     * @param ManagerConfig $managerConfig
+     * @param string $projectDir
      */
-    public function __construct(ManagerConfig $managerConfig)
+    public function __construct(string $projectDir)
     {
         parent::__construct();
 
-        $this->managerConfig = $managerConfig;
+        $this->projectDir = $projectDir;
     }
 
     /**
@@ -42,8 +40,8 @@ class GetConfigCommand extends Command
         parent::configure();
 
         $this
-            ->setName('config:get')
-            ->setDescription('Gets the Contao Manager configuration as JSON string.')
+            ->setName('access-key:get')
+            ->setDescription('Gets the debug access key.')
         ;
     }
 
@@ -52,6 +50,16 @@ class GetConfigCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        $output->writeln(json_encode($this->managerConfig->all()));
+        $path = $this->projectDir.'/.env';
+
+        if (!file_exists($path)) {
+            return;
+        }
+
+        $vars = (new Dotenv())->parse(file_get_contents($path));
+
+        if (isset($vars['APP_DEV_ACCESSKEY'])) {
+            $output->write($vars['APP_DEV_ACCESSKEY']);
+        }
     }
 }

--- a/src/Api/Command/RemoveAccesskeyCommand.php
+++ b/src/Api/Command/RemoveAccesskeyCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\ManagerBundle\Api\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class RemoveAccesskeyCommand extends Command
+{
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     * @param string $projectDir
+     */
+    public function __construct(string $projectDir)
+    {
+        parent::__construct();
+
+        $this->projectDir = $projectDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('access-key:remove')
+            ->setDescription('Removes the debug access key.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $fs = new Filesystem();
+        $path = $this->projectDir.'/.env';
+
+        if (!$fs->exists($path)) {
+            return;
+        }
+
+        $content = '';
+        $lines = file($path, FILE_IGNORE_NEW_LINES);
+
+        if (false === $lines) {
+            throw new \RuntimeException(sprintf('Could not read "%s" file.', $path));
+        }
+
+        foreach ($lines as $line) {
+            if (0 === strpos($line, 'APP_DEV_ACCESSKEY=')) {
+                continue;
+            }
+
+            $content .= $line."\n";
+        }
+
+        if (empty($content)) {
+            $fs->remove($path);
+        } else {
+            $fs->dumpFile($path, $content);
+        }
+    }
+}

--- a/src/Api/Command/SetAccesskeyCommand.php
+++ b/src/Api/Command/SetAccesskeyCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2017 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\ManagerBundle\Api\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class SetAccesskeyCommand extends Command
+{
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     * @param string $projectDir
+     */
+    public function __construct(string $projectDir)
+    {
+        parent::__construct();
+
+        $this->projectDir = $projectDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('access-key:set')
+            ->setDescription('Sets the debug access key.')
+            ->addArgument('value', InputArgument::REQUIRED, 'The access key')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $fs = new Filesystem();
+        $path = $this->projectDir.'/.env';
+        $content = '';
+
+        if ($fs->exists($path)) {
+            $lines = file($path, FILE_IGNORE_NEW_LINES);
+
+            if (false === $lines) {
+                throw new \RuntimeException(sprintf('Could not read "%s" file.', $path));
+            }
+
+            foreach ($lines as $line) {
+                if (0 === strpos($line, 'APP_DEV_ACCESSKEY=')) {
+                    continue;
+                }
+
+                $content .= $line."\n";
+            }
+        }
+
+        $content .= 'APP_DEV_ACCESSKEY='.escapeshellarg($input->getArgument('value'))."\n";
+
+        $fs->dumpFile($path, $content);
+    }
+}

--- a/src/Api/Command/SetConfigCommand.php
+++ b/src/Api/Command/SetConfigCommand.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Api\Command;
 
-use Contao\ManagerBundle\Api\Application;
+use Contao\ManagerBundle\Api\ManagerConfig;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +20,21 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SetConfigCommand extends Command
 {
+    /**
+     * @var ManagerConfig
+     */
+    private $managerConfig;
+
+    /**
+     * @param ManagerConfig $managerConfig
+     */
+    public function __construct(ManagerConfig $managerConfig)
+    {
+        parent::__construct();
+
+        $this->managerConfig = $managerConfig;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -30,11 +45,7 @@ class SetConfigCommand extends Command
         $this
             ->setName('config:set')
             ->setDescription('Sets the Contao Manager configuration from a JSON string.')
-            ->setDefinition(
-                [
-                    new InputArgument('json', InputArgument::REQUIRED, 'The configuration as JSON string'),
-                ]
-            )
+            ->addArgument('json', InputArgument::REQUIRED, 'The configuration as JSON string')
         ;
     }
 
@@ -43,18 +54,12 @@ class SetConfigCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        $application = $this->getApplication();
-
-        if (!$application instanceof Application) {
-            throw new \RuntimeException('The application has not been set');
-        }
-
         $data = @json_decode($input->getArgument('json'), true);
 
         if (null === $data) {
             throw new \RuntimeException('Invalid JSON: '.json_last_error_msg());
         }
 
-        $application->getManagerConfig()->write($data);
+        $this->managerConfig->write($data);
     }
 }

--- a/src/Command/InstallWebDirCommand.php
+++ b/src/Command/InstallWebDirCommand.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\ManagerBundle\Command;
 
 use Contao\CoreBundle\Command\AbstractLockedCommand;
-use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -201,16 +200,6 @@ class InstallWebDirCommand extends AbstractLockedCommand
         $password = $input->getOption('password');
 
         if (false === $password && false === $user) {
-            $kernel = $this->getContainer()->get('kernel');
-
-            if ($kernel instanceof ContaoKernel) {
-                $config = $kernel->getManagerConfig()->all();
-
-                if (isset($config['contao_manager']['dev_accesskey'])) {
-                    $this->addToDotEnv($projectDir, 'APP_DEV_ACCESSKEY', $config['contao_manager']['dev_accesskey']);
-                }
-            }
-
             return;
         }
 

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -30,6 +30,9 @@ class ScriptHandler
         static::addAppDirectory();
         static::executeCommand('contao:install-web-dir', $event);
         static::executeCommand('cache:clear', $event);
+        static::executeCommand('doctrine:cache:clear-metadata', $event);
+        static::executeCommand('doctrine:cache:clear-query', $event);
+        static::executeCommand('doctrine:cache:clear-result', $event);
         static::executeCommand('assets:install --symlink --relative', $event);
         static::executeCommand('contao:install', $event);
         static::executeCommand('contao:symlinks', $event);

--- a/src/HttpKernel/ContaoKernel.php
+++ b/src/HttpKernel/ContaoKernel.php
@@ -109,14 +109,6 @@ class ContaoKernel extends Kernel
     {
         if (null === $this->pluginLoader) {
             $this->pluginLoader = new PluginLoader($this->getProjectDir().'/vendor/composer/installed.json');
-
-            $config = $this->getManagerConfig()->all();
-
-            if (isset($config['contao_manager']['disabled_packages'])
-                && \is_array($config['contao_manager']['disabled_packages'])
-            ) {
-                $this->pluginLoader->setDisabledPackages($config['contao_manager']['disabled_packages']);
-            }
         }
 
         return $this->pluginLoader;

--- a/src/Resources/skeleton/app/config.yml
+++ b/src/Resources/skeleton/app/config.yml
@@ -55,6 +55,36 @@ doctrine:
                 class: "Contao\\CoreBundle\\Doctrine\\DBAL\\Types\\BinaryStringType"
                 commented: true
 
+    orm:
+        auto_generate_proxy_classes: "%kernel.debug%"
+        naming_strategy: doctrine.orm.naming_strategy.default
+        auto_mapping: true
+
+        metadata_cache_driver:
+            type: service
+            id: doctrine_cache.providers.doctrine_metadata_cache
+        result_cache_driver:
+            type: service
+            id: doctrine_cache.providers.doctrine_result_cache
+        query_cache_driver:
+            type: service
+            id: doctrine_cache.providers.doctrine_query_cache
+
+doctrine_cache:
+    providers:
+        doctrine_metadata_cache:
+            file_system:
+                extension: ".metadata"
+                directory: "%kernel.cache_dir%/doctrine/cache"
+        doctrine_result_cache:
+            file_system:
+                extension: ".result"
+                directory: "%kernel.cache_dir%/doctrine/cache"
+        doctrine_query_cache:
+            file_system:
+                extension: ".query"
+                directory: "%kernel.cache_dir%/doctrine/cache"
+
 # SwiftMailer configuration
 swiftmailer:
     transport: "%mailer_transport%"

--- a/src/Resources/skeleton/app/security.yml
+++ b/src/Resources/skeleton/app/security.yml
@@ -30,19 +30,18 @@ security:
             switch_user: true
             logout_on_user_change: true
 
-            form_login:
+            contao_login:
                 login_path: contao_backend_login
                 check_path: contao_backend_login
                 default_target_path: contao_backend
+                always_use_default_target_path: true
                 success_handler: contao.security.authentication_success_handler
                 failure_handler: contao.security.authentication_failure_handler
-                username_parameter: username
-                password_parameter: password
+                remember_me: false
 
             logout:
                 path: contao_backend_logout
-                target: contao_backend
-                success_handler: contao.security.logout_success_handler
+                target: contao_backend_login
                 handlers:
                     - contao.security.logout_handler
 
@@ -54,14 +53,13 @@ security:
             switch_user: false
             logout_on_user_change: true
 
-            form_login:
+            contao_login:
                 login_path: contao_frontend_login
                 check_path: contao_frontend_login
-                default_target_path: contao_index
+                default_target_path: contao_root
+                failure_path: contao_root
                 failure_handler: contao.security.authentication_failure_handler
-                success_handler: contao.security.authentication_success_handler
-                username_parameter: username
-                password_parameter: password
+                success_handler: contao.security.frontend_authentication_success_handler
                 remember_me: true
 
             remember_me:
@@ -70,7 +68,8 @@ security:
 
             logout:
                 path: contao_frontend_logout
-                success_handler: contao.security.logout_success_handler
+                target: contao_root
+                success_handler: contao.security.frontend_logout_success_handler
                 handlers:
                     - contao.security.logout_handler
 

--- a/tests/Command/InstallWebDirCommandTest.php
+++ b/tests/Command/InstallWebDirCommandTest.php
@@ -167,29 +167,6 @@ class InstallWebDirCommandTest extends ContaoTestCase
         $this->assertTrue(password_verify('foo:bar', $env['APP_DEV_ACCESSKEY']));
     }
 
-    public function testAccesskeyFromManagerConfig(): void
-    {
-        $config = $this->createMock(ManagerConfig::class);
-
-        $config
-            ->expects($this->atLeastOnce())
-            ->method('all')
-            ->willReturn(['contao_manager' => ['dev_accesskey' => password_hash('foo:bar', PASSWORD_DEFAULT)]])
-        ;
-
-        $this->command->setApplication($this->mockApplication($config));
-
-        $commandTester = new CommandTester($this->command);
-        $commandTester->execute(['path' => $this->getTempDir()]);
-
-        $this->assertFileExists($this->getTempDir().'/.env');
-
-        $env = (new Dotenv())->parse(file_get_contents($this->getTempDir().'/.env'), $this->getTempDir().'/.env');
-
-        $this->assertArrayHasKey('APP_DEV_ACCESSKEY', $env);
-        $this->assertTrue(password_verify('foo:bar', $env['APP_DEV_ACCESSKEY']));
-    }
-
     public function testAccesskeyFromInput(): void
     {
         $commandTester = new CommandTester($this->command);


### PR DESCRIPTION
This PR activates ORM in a Contao Managed Edition.

Currently blocked by https://github.com/contao/core-bundle/pull/685 and follow-up PR for persistent remember me token, as we **must** have at least one entity in the application or Doctrine Schema (and therefore the install tool) will fail if ORM is enabled without entity.

/cc @leofeyer @bytehead 