### PR TITLE
Use toflar/psr6-symfony-http-cache-store

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "contao/installation-bundle": "4.5.*",
         "contao/manager-plugin": "^2.2",
         "doctrine/doctrine-bundle": "^1.6",
-        "friendsofsymfony/http-cache": "^2.0",
+        "friendsofsymfony/http-cache": "^2.2",
         "lexik/maintenance-bundle": "^2.1.3",
         "nelmio/security-bundle": "^2.2",
         "php-http/guzzle6-adapter": "^1.1",
@@ -24,7 +24,6 @@
         "symfony/swiftmailer-bundle": "^3.1.5",
         "symfony/symfony": "3.4.*",
         "terminal42/header-replay-bundle": "^1.4.2",
-        "friendsofsymfony/http-cache": "^2.2",
         "toflar/psr6-symfony-http-cache-store": "^1.0.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
         "symfony/monolog-bundle": "^3.1",
         "symfony/swiftmailer-bundle": "^3.1.5",
         "symfony/symfony": "3.4.*",
-        "terminal42/header-replay-bundle": "^1.4.2"
+        "terminal42/header-replay-bundle": "^1.4.2",
+        "friendsofsymfony/http-cache": "^2.2",
+        "toflar/psr6-symfony-http-cache-store": "^1.0.2"
     },
     "require-dev": {
         "composer/composer": "^1.0",

--- a/src/HttpKernel/ContaoCache.php
+++ b/src/HttpKernel/ContaoCache.php
@@ -54,7 +54,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     protected function createStore()
     {
         return new Psr6Store([
-            'cache_directory' => $this->cacheDir,
+            'cache_directory' => $this->cacheDir ?: $this->kernel->getCacheDir().'/http_cache',
             'cache_tags_header' => 'X-Cache-Tags',
         ]);
     }

--- a/src/HttpKernel/ContaoCache.php
+++ b/src/HttpKernel/ContaoCache.php
@@ -14,11 +14,14 @@ namespace Contao\ManagerBundle\HttpKernel;
 
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
+use FOS\HttpCache\SymfonyCache\PurgeListener;
+use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Terminal42\HeaderReplay\SymfonyCache\HeaderReplaySubscriber;
+use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class ContaoCache extends HttpCache implements CacheInvalidation
 {
@@ -32,6 +35,8 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     {
         parent::__construct($kernel, $cacheDir);
 
+        $this->addSubscriber(new PurgeListener());
+        $this->addSubscriber(new PurgeTagsListener());
         $this->addSubscriber(new HeaderReplaySubscriber(['ignore_cookies' => ['/^csrf_./']]));
     }
 
@@ -41,5 +46,16 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     public function fetch(Request $request, $catch = false): Response
     {
         return parent::fetch($request, $catch);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createStore()
+    {
+        return new Psr6Store([
+            'cache_directory' => $this->cacheDir,
+            'cache_tags_header' => 'X-Cache-Tags',
+        ]);
     }
 }

--- a/tests/HttpKernel/ContaoCacheTest.php
+++ b/tests/HttpKernel/ContaoCacheTest.php
@@ -19,7 +19,6 @@ use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Terminal42\HeaderReplay\SymfonyCache\HeaderReplaySubscriber;
-use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class ContaoCacheTest extends ContaoTestCase
 {
@@ -61,10 +60,10 @@ class ContaoCacheTest extends ContaoTestCase
         $this->assertInstanceOf(PurgeTagsListener::class, $preInvalidateListeners[1][0]);
     }
 
-    public function testCreatesTheCacheStore()
+    public function testCreatesTheCacheStore(): void
     {
         $cache = new ContaoCache($this->createMock(KernelInterface::class), $this->getTempDir());
 
-        $this->assertInstanceOf(Psr6Store::class, $cache->getStore());
+        $this->assertInstanceOf('Toflar\Psr6HttpCacheStore\Psr6Store', $cache->getStore());
     }
 }

--- a/tests/HttpKernel/ContaoCacheTest.php
+++ b/tests/HttpKernel/ContaoCacheTest.php
@@ -59,6 +59,11 @@ class ContaoCacheTest extends ContaoTestCase
         $preInvalidateListeners = $dispatcher->getListeners(Events::PRE_INVALIDATE);
         $this->assertInstanceOf(PurgeListener::class, $preInvalidateListeners[0][0]);
         $this->assertInstanceOf(PurgeTagsListener::class, $preInvalidateListeners[1][0]);
+    }
+
+    public function testCreatesTheCacheStore()
+    {
+        $cache = new ContaoCache($this->createMock(KernelInterface::class), $this->getTempDir());
 
         $this->assertInstanceOf(Psr6Store::class, $cache->getStore());
     }

--- a/tests/HttpKernel/ContaoCacheTest.php
+++ b/tests/HttpKernel/ContaoCacheTest.php
@@ -15,8 +15,11 @@ namespace Contao\ManagerBundle\Tests\HttpKernel;
 use Contao\ManagerBundle\HttpKernel\ContaoCache;
 use Contao\TestCase\ContaoTestCase;
 use FOS\HttpCache\SymfonyCache\Events;
+use FOS\HttpCache\SymfonyCache\PurgeListener;
+use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Terminal42\HeaderReplay\SymfonyCache\HeaderReplaySubscriber;
+use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class ContaoCacheTest extends ContaoTestCase
 {
@@ -52,5 +55,11 @@ class ContaoCacheTest extends ContaoTestCase
             ],
             $options
         );
+
+        $preInvalidateListeners = $dispatcher->getListeners(Events::PRE_INVALIDATE);
+        $this->assertInstanceOf(PurgeListener::class, $preInvalidateListeners[0][0]);
+        $this->assertInstanceOf(PurgeTagsListener::class, $preInvalidateListeners[1][0]);
+
+        $this->assertInstanceOf(Psr6Store::class, $cache->getStore());
     }
 }


### PR DESCRIPTION
After almost a year of work on Symfony, then on my custom library, then on FOSHttpCache we are finally able to use the components and their new functionality in Contao.
It mainly unlocks 4 things:

1. Our reverse proxy (`var/cache/http_cache`) is faster now than before due to optimizations in the `Psr6Store`.
2. Our reverse proxy (`var/cache/http_cache`) is now self-managed which means it cleans up old cache entries automatically instead of filling up the cache directory forever.
3. The new cache allows for more options providing the possibility to use a different back end if you don't want to use the local filesystem.
4. Finally, we can tag cache entries! 🎉 With these changes in place, the Contao ME is configured automatically in a way that you can easily tag a response and invalidate it later on. See http://foshttpcachebundle.readthedocs.io/en/latest/features/tagging.html#tagging-and-invalidating-from-php-code for the documentation on how to tag and invalidate again. It opens up an armada of new possibilities. You can now for example tag page responses so we could offer clearing the page cache on a per-page basis. Or you could cache a news entry forever until somebody edits it again etc. pp.

I did not include any integrations yet but I'm sure e.g. @dmolineus will want to try adding them as soon as this got merged into master 😄 

Wow, one year of work and it ends up being a few lines of code to integrate third party code. Composer FTW 😄 