### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6 || ^7.0",
         "contao/core-bundle": "4.4.*",
         "contao/installation-bundle": "4.4.*",
         "contao/manager-plugin": "^2.1",
@@ -20,7 +20,7 @@
         "nelmio/security-bundle": "^2.2",
         "php-http/guzzle6-adapter": "^1.1",
         "sensio/framework-extra-bundle": "^3.0.2",
-        "symfony/monolog-bundle": "^2.8|^3.0",
+        "symfony/monolog-bundle": "^2.8 || ^3.0",
         "symfony/swiftmailer-bundle": "^2.3",
         "symfony/symfony": "^3.3",
         "terminal42/header-replay-bundle": "^1.4.2"


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range).