### PR TITLE
[RTM] Enable the FOS cache bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "contao/installation-bundle": "4.5.*",
         "contao/manager-plugin": "^2.2",
         "doctrine/doctrine-bundle": "^1.6",
-        "friendsofsymfony/http-cache": "^2.2",
+        "friendsofsymfony/http-cache-bundle": "^2.3",
         "lexik/maintenance-bundle": "^2.1.3",
         "nelmio/security-bundle": "^2.2",
         "php-http/guzzle6-adapter": "^1.1",

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -25,6 +25,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\DriverException;
+use FOS\HttpCacheBundle\FOSHttpCacheBundle;
 use Lexik\Bundle\MaintenanceBundle\LexikMaintenanceBundle;
 use Nelmio\CorsBundle\NelmioCorsBundle;
 use Nelmio\SecurityBundle\NelmioSecurityBundle;
@@ -87,6 +88,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             BundleConfig::create(NelmioCorsBundle::class),
             BundleConfig::create(NelmioSecurityBundle::class),
             BundleConfig::create(SensioFrameworkExtraBundle::class),
+            BundleConfig::create(FOSHttpCacheBundle::class),
             BundleConfig::create(ContaoManagerBundle::class),
             BundleConfig::create(DebugBundle::class)->setLoadInProduction(false),
             BundleConfig::create(WebProfilerBundle::class)->setLoadInProduction(false),

--- a/src/HttpKernel/ContaoCache.php
+++ b/src/HttpKernel/ContaoCache.php
@@ -19,7 +19,6 @@ use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\KernelInterface;
 use Terminal42\HeaderReplay\SymfonyCache\HeaderReplaySubscriber;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
 
@@ -28,16 +27,18 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     use EventDispatchingHttpCache;
 
     /**
-     * @param KernelInterface $kernel
-     * @param string|null     $cacheDir
+     * @param ContaoKernel $kernel
+     * @param string|null  $cacheDir
      */
-    public function __construct(KernelInterface $kernel, string $cacheDir = null)
+    public function __construct(ContaoKernel $kernel, string $cacheDir = null)
     {
         parent::__construct($kernel, $cacheDir);
 
         $this->addSubscriber(new PurgeListener());
         $this->addSubscriber(new PurgeTagsListener());
         $this->addSubscriber(new HeaderReplaySubscriber(['ignore_cookies' => ['/^csrf_./']]));
+
+        $kernel->setHttpCache($this);
     }
 
     /**

--- a/src/HttpKernel/ContaoKernel.php
+++ b/src/HttpKernel/ContaoKernel.php
@@ -21,14 +21,18 @@ use Contao\ManagerPlugin\Bundle\Parser\JsonParser;
 use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use Contao\ManagerPlugin\Config\ContainerBuilder as PluginContainerBuilder;
 use Contao\ManagerPlugin\PluginLoader;
+use FOS\HttpCache\SymfonyCache\HttpCacheAware;
+use FOS\HttpCache\SymfonyCache\HttpCacheProvider;
 use ProxyManager\Configuration;
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
-class ContaoKernel extends Kernel
+class ContaoKernel extends Kernel implements HttpCacheProvider
 {
+    use HttpCacheAware;
+
     /**
      * @var string
      */

--- a/src/Resources/skeleton/app/config.yml
+++ b/src/Resources/skeleton/app/config.yml
@@ -89,3 +89,13 @@ nelmio_security:
     xss_protection:
         enabled: true
         mode_block: true
+
+# FOS HttpCache
+fos_http_cache:
+    proxy_client:
+        symfony:
+            use_kernel_dispatcher: true
+    cache_manager:
+        enabled: true
+    tags:
+        enabled: true

--- a/src/Resources/skeleton/app/config.yml
+++ b/src/Resources/skeleton/app/config.yml
@@ -90,7 +90,7 @@ nelmio_security:
         enabled: true
         mode_block: true
 
-# FOS HttpCache
+# FOS HttpCache configuration
 fos_http_cache:
     proxy_client:
         symfony:

--- a/src/Resources/skeleton/web/app.php
+++ b/src/Resources/skeleton/web/app.php
@@ -27,12 +27,11 @@ ContaoKernel::setProjectDir(\dirname(__DIR__));
 $kernel = new ContaoKernel('prod', false);
 
 // Enable the Symfony reverse proxy
-$cache = new ContaoCache($kernel);
-$kernel->setHttpCache($cache);
+$kernel = new ContaoCache($kernel);
 Request::enableHttpMethodParameterOverride();
 
 // Handle the request
 $request = Request::createFromGlobals();
-$response = $cache->handle($request);
+$response = $kernel->handle($request);
 $response->send();
-$cache->terminate($request, $response);
+$kernel->terminate($request, $response);

--- a/src/Resources/skeleton/web/app.php
+++ b/src/Resources/skeleton/web/app.php
@@ -27,11 +27,12 @@ ContaoKernel::setProjectDir(\dirname(__DIR__));
 $kernel = new ContaoKernel('prod', false);
 
 // Enable the Symfony reverse proxy
-$kernel = new ContaoCache($kernel);
+$cache = new ContaoCache($kernel);
+$kernel->setHttpCache($cache);
 Request::enableHttpMethodParameterOverride();
 
 // Handle the request
 $request = Request::createFromGlobals();
-$response = $kernel->handle($request);
+$response = $cache->handle($request);
 $response->send();
-$kernel->terminate($request, $response);
+$cache->terminate($request, $response);

--- a/tests/ContaoManager/PluginTest.php
+++ b/tests/ContaoManager/PluginTest.php
@@ -59,7 +59,7 @@ class PluginTest extends ContaoTestCase
         $plugin = new Plugin();
         $configs = $plugin->getBundles($parser);
 
-        $this->assertCount(17, $configs);
+        $this->assertCount(18, $configs);
         $this->assertContains('foo1', $configs);
         $this->assertContains('foo2', $configs);
         $this->assertNotContains('foo3', $configs);

--- a/tests/HttpKernel/ContaoCacheTest.php
+++ b/tests/HttpKernel/ContaoCacheTest.php
@@ -19,6 +19,7 @@ use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Terminal42\HeaderReplay\SymfonyCache\HeaderReplaySubscriber;
+use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class ContaoCacheTest extends ContaoTestCase
 {
@@ -64,6 +65,6 @@ class ContaoCacheTest extends ContaoTestCase
     {
         $cache = new ContaoCache($this->createMock(KernelInterface::class), $this->getTempDir());
 
-        $this->assertInstanceOf('Toflar\Psr6HttpCacheStore\Psr6Store', $cache->getStore());
+        $this->assertInstanceOf(Psr6Store::class, $cache->getStore());
     }
 }

--- a/tests/HttpKernel/ContaoCacheTest.php
+++ b/tests/HttpKernel/ContaoCacheTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 namespace Contao\ManagerBundle\Tests\HttpKernel;
 
 use Contao\ManagerBundle\HttpKernel\ContaoCache;
+use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Contao\TestCase\ContaoTestCase;
 use FOS\HttpCache\SymfonyCache\Events;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
-use Symfony\Component\HttpKernel\KernelInterface;
 use Terminal42\HeaderReplay\SymfonyCache\HeaderReplaySubscriber;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
 
@@ -25,7 +25,7 @@ class ContaoCacheTest extends ContaoTestCase
 {
     public function testInstantiation(): void
     {
-        $cache = new ContaoCache($this->createMock(KernelInterface::class), $this->getTempDir());
+        $cache = new ContaoCache($this->createMock(ContaoKernel::class), $this->getTempDir());
 
         $this->assertInstanceOf('Contao\ManagerBundle\HttpKernel\ContaoCache', $cache);
         $this->assertInstanceOf('Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache', $cache);
@@ -33,7 +33,7 @@ class ContaoCacheTest extends ContaoTestCase
 
     public function testAddsTheEventSubscribers(): void
     {
-        $cache = new ContaoCache($this->createMock(KernelInterface::class), $this->getTempDir());
+        $cache = new ContaoCache($this->createMock(ContaoKernel::class), $this->getTempDir());
         $dispatcher = $cache->getEventDispatcher();
         $preHandleListeners = $dispatcher->getListeners(Events::PRE_HANDLE);
         $headerReplayListener = $preHandleListeners[0][0];
@@ -63,7 +63,7 @@ class ContaoCacheTest extends ContaoTestCase
 
     public function testCreatesTheCacheStore(): void
     {
-        $cache = new ContaoCache($this->createMock(KernelInterface::class), $this->getTempDir());
+        $cache = new ContaoCache($this->createMock(ContaoKernel::class), $this->getTempDir());
 
         $this->assertInstanceOf(Psr6Store::class, $cache->getStore());
     }

--- a/tests/HttpKernel/ContaoKernelTest.php
+++ b/tests/HttpKernel/ContaoKernelTest.php
@@ -20,7 +20,6 @@ use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use Contao\ManagerPlugin\PluginLoader;
 use Contao\TestCase\ContaoTestCase;
-use FOS\HttpCache\SymfonyCache\HttpCacheProvider;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -32,6 +31,7 @@ class ContaoKernelTest extends ContaoTestCase
 
         $this->assertInstanceOf('Contao\ManagerBundle\HttpKernel\ContaoKernel', $kernel);
         $this->assertInstanceOf('Symfony\Component\HttpKernel\Kernel', $kernel);
+        $this->assertInstanceOf('FOS\HttpCache\SymfonyCache\HttpCacheProvider', $kernel);
     }
 
     public function testRegisterBundles(): void
@@ -198,13 +198,6 @@ class ContaoKernelTest extends ContaoTestCase
         $kernel->registerContainerConfiguration($loader);
 
         $this->assertSame('sendmail', $container->getParameter('mailer_transport'));
-    }
-
-    public function testImplementsFOSHttpCacheProvider(): void
-    {
-        $kernel = $this->mockKernel($this->getTempDir());
-
-        $this->assertInstanceOf(HttpCacheProvider::class, $kernel);
     }
 
     /**

--- a/tests/HttpKernel/ContaoKernelTest.php
+++ b/tests/HttpKernel/ContaoKernelTest.php
@@ -20,6 +20,7 @@ use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use Contao\ManagerPlugin\PluginLoader;
 use Contao\TestCase\ContaoTestCase;
+use FOS\HttpCache\SymfonyCache\HttpCacheProvider;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -197,6 +198,13 @@ class ContaoKernelTest extends ContaoTestCase
         $kernel->registerContainerConfiguration($loader);
 
         $this->assertSame('sendmail', $container->getParameter('mailer_transport'));
+    }
+
+    public function testImplementsFOSHttpCacheProvider(): void
+    {
+        $kernel = $this->mockKernel($this->getTempDir());
+
+        $this->assertInstanceOf(HttpCacheProvider::class, $kernel);
     }
 
     /**


### PR DESCRIPTION
While enabling the FOSHttpCacheBundle I noticed that configuration for purging the tags is still a bit cumbersome so I worked on this (https://github.com/FriendsOfSymfony/FOSHttpCache/pull/419) and I am trying to get this into the bundle because it will greatly simplify our integration.
I'll keep this PR up-to-date with the changes on FOSHttpCache(Bundle). Once - hopefully - this gets all released as version 2.3, I'll finish this PR so it can be merged.