### PR TITLE
Replace the access-key API command with generic dot-env commands

### DIFF
--- a/src/Api/Application.php
+++ b/src/Api/Application.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Api;
 
-use Contao\ManagerBundle\Api\Command\GetDotEnvCommand;
 use Contao\ManagerBundle\Api\Command\GetConfigCommand;
+use Contao\ManagerBundle\Api\Command\GetDotEnvCommand;
 use Contao\ManagerBundle\Api\Command\RemoveDotEnvCommand;
-use Contao\ManagerBundle\Api\Command\SetDotEnvCommand;
 use Contao\ManagerBundle\Api\Command\SetConfigCommand;
+use Contao\ManagerBundle\Api\Command\SetDotEnvCommand;
 use Contao\ManagerBundle\Api\Command\VersionCommand;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Api/Application.php
+++ b/src/Api/Application.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Api;
 
-use Contao\ManagerBundle\Api\Command\GetAccesskeyCommand;
+use Contao\ManagerBundle\Api\Command\GetDotEnvCommand;
 use Contao\ManagerBundle\Api\Command\GetConfigCommand;
-use Contao\ManagerBundle\Api\Command\RemoveAccesskeyCommand;
-use Contao\ManagerBundle\Api\Command\SetAccesskeyCommand;
+use Contao\ManagerBundle\Api\Command\RemoveDotEnvCommand;
+use Contao\ManagerBundle\Api\Command\SetDotEnvCommand;
 use Contao\ManagerBundle\Api\Command\SetConfigCommand;
 use Contao\ManagerBundle\Api\Command\VersionCommand;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends BaseApplication
 {
-    public const VERSION = 1;
+    public const VERSION = 2;
 
     /**
      * @var string
@@ -103,9 +103,9 @@ class Application extends BaseApplication
         $commands[] = new VersionCommand();
         $commands[] = new GetConfigCommand($this->getManagerConfig());
         $commands[] = new SetConfigCommand($this->getManagerConfig());
-        $commands[] = new GetAccesskeyCommand($this->projectDir);
-        $commands[] = new SetAccesskeyCommand($this->projectDir);
-        $commands[] = new RemoveAccesskeyCommand($this->projectDir);
+        $commands[] = new GetDotEnvCommand($this->projectDir);
+        $commands[] = new SetDotEnvCommand($this->projectDir);
+        $commands[] = new RemoveDotEnvCommand($this->projectDir);
 
         return $commands;
     }

--- a/src/Api/Application.php
+++ b/src/Api/Application.php
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends BaseApplication
 {
-    public const VERSION = 2;
+    public const VERSION = '2';
 
     /**
      * @var string
@@ -86,11 +86,9 @@ class Application extends BaseApplication
      */
     protected function getDefaultInputDefinition(): InputDefinition
     {
-        return new InputDefinition(
-            [
-                new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
-            ]
-        );
+        return new InputDefinition([
+            new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
+        ]);
     }
 
     /**

--- a/src/Api/Command/SetDotEnvCommand.php
+++ b/src/Api/Command/SetDotEnvCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-class SetAccesskeyCommand extends Command
+class SetDotEnvCommand extends Command
 {
     /**
      * @var string
@@ -43,9 +43,10 @@ class SetAccesskeyCommand extends Command
         parent::configure();
 
         $this
-            ->setName('access-key:set')
-            ->setDescription('Sets the debug access key.')
-            ->addArgument('value', InputArgument::REQUIRED, 'The access key')
+            ->setName('dot-env:set')
+            ->setDescription('Writes a parameter to the .env file.')
+            ->addArgument('key', InputArgument::REQUIRED, 'The variable name')
+            ->addArgument('value', InputArgument::REQUIRED, 'The new value')
         ;
     }
 
@@ -58,6 +59,9 @@ class SetAccesskeyCommand extends Command
         $path = $this->projectDir.'/.env';
         $content = '';
 
+        $key = $input->getArgument('key');
+        $value = $input->getArgument('value');
+
         if ($fs->exists($path)) {
             $lines = file($path, FILE_IGNORE_NEW_LINES);
 
@@ -66,7 +70,7 @@ class SetAccesskeyCommand extends Command
             }
 
             foreach ($lines as $line) {
-                if (0 === strncmp($line, 'APP_DEV_ACCESSKEY=', 18)) {
+                if (0 === strpos($line, $key.'=')) {
                     continue;
                 }
 
@@ -74,7 +78,7 @@ class SetAccesskeyCommand extends Command
             }
         }
 
-        $content .= 'APP_DEV_ACCESSKEY='.escapeshellarg($input->getArgument('value'))."\n";
+        $content .= $key.'='.escapeshellarg($value)."\n";
 
         $fs->dumpFile($path, $content);
     }

--- a/tests/Api/Command/GetDotEnvCommandTest.php
+++ b/tests/Api/Command/GetDotEnvCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Tests\Api\Command;
+
+use Contao\ManagerBundle\Api\Command\GetDotEnvCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class GetDotEnvCommandTest extends TestCase
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $tempdir;
+
+    /**
+     * @var string
+     */
+    private $tempfile;
+
+    /**
+     * @var GetDotEnvCommand
+     */
+    private $command;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+        $this->tempdir = sys_get_temp_dir().'/'.uniqid('GetDotEnvCommand-', false);
+        $this->tempfile = $this->tempdir.'/.env';
+
+        $this->filesystem->mkdir($this->tempdir);
+
+        $this->command = new GetDotEnvCommand($this->tempdir);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->filesystem->remove($this->tempdir);
+    }
+
+    public function testInstantiation(): void
+    {
+        $this->assertInstanceOf('Contao\ManagerBundle\Api\Command\GetDotEnvCommand', $this->command);
+    }
+
+    public function testHasCorrectNameAndArguments(): void
+    {
+        $this->assertSame('dot-env:get', $this->command->getName());
+        $this->assertTrue($this->command->getDefinition()->hasArgument('key'));
+        $this->assertTrue($this->command->getDefinition()->getArgument('key')->isRequired());
+    }
+
+    public function testReadsDotEnvFile(): void
+    {
+        $this->filesystem->dumpFile($this->tempfile, 'FOO=BAR');
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO']);
+
+        $this->assertSame('BAR', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testOutputsNothingIfDotEnvDoesNotExist(): void
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO']);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testOutputsNothingIfKeyDoesNotExist(): void
+    {
+        $this->filesystem->dumpFile($this->tempfile, 'BAR=FOO');
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO']);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+}

--- a/tests/Api/Command/GetDotEnvCommandTest.php
+++ b/tests/Api/Command/GetDotEnvCommandTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 namespace Contao\ManagerBundle\Tests\Api\Command;
 
 use Contao\ManagerBundle\Api\Command\GetDotEnvCommand;
-use PHPUnit\Framework\TestCase;
+use Contao\TestCase\ContaoTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
-class GetDotEnvCommandTest extends TestCase
+class GetDotEnvCommandTest extends ContaoTestCase
 {
     /**
      * @var Filesystem
@@ -47,11 +47,8 @@ class GetDotEnvCommandTest extends TestCase
         parent::setUp();
 
         $this->filesystem = new Filesystem();
-        $this->tempdir = sys_get_temp_dir().'/'.uniqid('GetDotEnvCommand-', false);
+        $this->tempdir = $this->getTempDir();
         $this->tempfile = $this->tempdir.'/.env';
-
-        $this->filesystem->mkdir($this->tempdir);
-
         $this->command = new GetDotEnvCommand($this->tempdir);
     }
 

--- a/tests/Api/Command/RemoveDotEnvCommandTest.php
+++ b/tests/Api/Command/RemoveDotEnvCommandTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 namespace Contao\ManagerBundle\Tests\Api\Command;
 
 use Contao\ManagerBundle\Api\Command\RemoveDotEnvCommand;
-use PHPUnit\Framework\TestCase;
+use Contao\TestCase\ContaoTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
-class RemoveDotEnvCommandTest extends TestCase
+class RemoveDotEnvCommandTest extends ContaoTestCase
 {
     /**
      * @var Filesystem
@@ -47,11 +47,8 @@ class RemoveDotEnvCommandTest extends TestCase
         parent::setUp();
 
         $this->filesystem = new Filesystem();
-        $this->tempdir = sys_get_temp_dir().'/'.uniqid('RemoveDotEnvCommand-', false);
+        $this->tempdir = $this->getTempDir();
         $this->tempfile = $this->tempdir.'/.env';
-
-        $this->filesystem->mkdir($this->tempdir);
-
         $this->command = new RemoveDotEnvCommand($this->tempdir);
     }
 
@@ -86,7 +83,6 @@ class RemoveDotEnvCommandTest extends TestCase
 
         $this->assertSame('', $tester->getDisplay());
         $this->assertSame(0, $tester->getStatusCode());
-
         $this->assertFileExists($this->tempfile);
         $this->assertSame("BAR='FOO'\n", file_get_contents($this->tempfile));
     }
@@ -100,7 +96,6 @@ class RemoveDotEnvCommandTest extends TestCase
 
         $this->assertSame('', $tester->getDisplay());
         $this->assertSame(0, $tester->getStatusCode());
-
         $this->assertFileNotExists($this->tempfile);
     }
 

--- a/tests/Api/Command/RemoveDotEnvCommandTest.php
+++ b/tests/Api/Command/RemoveDotEnvCommandTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Tests\Api\Command;
+
+use Contao\ManagerBundle\Api\Command\RemoveDotEnvCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class RemoveDotEnvCommandTest extends TestCase
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $tempdir;
+
+    /**
+     * @var string
+     */
+    private $tempfile;
+
+    /**
+     * @var RemoveDotEnvCommand
+     */
+    private $command;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+        $this->tempdir = sys_get_temp_dir().'/'.uniqid('RemoveDotEnvCommand-', false);
+        $this->tempfile = $this->tempdir.'/.env';
+
+        $this->filesystem->mkdir($this->tempdir);
+
+        $this->command = new RemoveDotEnvCommand($this->tempdir);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->filesystem->remove($this->tempdir);
+    }
+
+    public function testInstantiation(): void
+    {
+        $this->assertInstanceOf('Contao\ManagerBundle\Api\Command\RemoveDotEnvCommand', $this->command);
+    }
+
+    public function testHasCorrectNameAndArguments(): void
+    {
+        $this->assertSame('dot-env:remove', $this->command->getName());
+        $this->assertTrue($this->command->getDefinition()->hasArgument('key'));
+        $this->assertTrue($this->command->getDefinition()->getArgument('key')->isRequired());
+    }
+
+    public function testRemovesKeyFromDotEnv(): void
+    {
+        $this->filesystem->dumpFile($this->tempfile, "BAR='FOO'\nFOO='BAR'\n");
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO']);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $this->assertFileExists($this->tempfile);
+        $this->assertSame("BAR='FOO'\n", file_get_contents($this->tempfile));
+    }
+
+    public function testRemovesDotEnvIfLastKeyIsRemoved(): void
+    {
+        $this->filesystem->dumpFile($this->tempfile, "FOO='BAR'\n");
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO']);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $this->assertFileNotExists($this->tempfile);
+    }
+
+    public function testIgnoresIfDotEnvDoesNotExist(): void
+    {
+        $this->assertFileNotExists($this->tempfile);
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO']);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+}

--- a/tests/Api/Command/SetDotEnvCommandTest.php
+++ b/tests/Api/Command/SetDotEnvCommandTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Tests\Api\Command;
+
+use Contao\ManagerBundle\Api\Command\SetDotEnvCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class SetDotEnvCommandTest extends TestCase
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $tempdir;
+
+    /**
+     * @var string
+     */
+    private $tempfile;
+
+    /**
+     * @var SetDotEnvCommand
+     */
+    private $command;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+        $this->tempdir = sys_get_temp_dir().'/'.uniqid('SetDotEnvCommand-', false);
+        $this->tempfile = $this->tempdir.'/.env';
+
+        $this->filesystem->mkdir($this->tempdir);
+
+        $this->command = new SetDotEnvCommand($this->tempdir);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->filesystem->remove($this->tempdir);
+    }
+
+    public function testInstantiation(): void
+    {
+        $this->assertInstanceOf('Contao\ManagerBundle\Api\Command\SetDotEnvCommand', $this->command);
+    }
+
+    public function testHasCorrectNameAndArguments(): void
+    {
+        $this->assertSame('dot-env:set', $this->command->getName());
+        $this->assertTrue($this->command->getDefinition()->hasArgument('key'));
+        $this->assertTrue($this->command->getDefinition()->getArgument('key')->isRequired());
+        $this->assertTrue($this->command->getDefinition()->hasArgument('value'));
+        $this->assertTrue($this->command->getDefinition()->getArgument('value')->isRequired());
+    }
+
+    public function testCreatesDotEnvFileIfItDoesNotExist(): void
+    {
+        $this->assertFileNotExists($this->tempfile);
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO', 'value' => 'BAR']);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $this->assertFileExists($this->tempfile);
+        $this->assertSame("FOO='BAR'\n", file_get_contents($this->tempfile));
+    }
+
+    public function testAppendsToDotEnvFileIfItExists(): void
+    {
+        $this->filesystem->dumpFile($this->tempfile, "BAR='FOO'\n");
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO', 'value' => 'BAR']);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $this->assertFileExists($this->tempfile);
+        $this->assertSame("BAR='FOO'\nFOO='BAR'\n", file_get_contents($this->tempfile));
+    }
+
+    public function testOverwriteDotEnvIfKeyExists(): void
+    {
+        $this->filesystem->dumpFile($this->tempfile, "BAR='FOO'\nFOO='FOO'\n");
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO', 'value' => 'BAR']);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $this->assertFileExists($this->tempfile);
+        $this->assertSame("BAR='FOO'\nFOO='BAR'\n", file_get_contents($this->tempfile));
+    }
+
+    public function testEscapesShellArguments(): void
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute(['key' => 'FOO', 'value' => "UNESCAPED ' STRING"]);
+
+        $this->assertSame('', $tester->getDisplay());
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $this->assertFileExists($this->tempfile);
+        $this->assertSame("FOO='UNESCAPED '\'' STRING'\n", file_get_contents($this->tempfile));
+    }
+}

--- a/tests/Api/Command/SetDotEnvCommandTest.php
+++ b/tests/Api/Command/SetDotEnvCommandTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 namespace Contao\ManagerBundle\Tests\Api\Command;
 
 use Contao\ManagerBundle\Api\Command\SetDotEnvCommand;
-use PHPUnit\Framework\TestCase;
+use Contao\TestCase\ContaoTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
-class SetDotEnvCommandTest extends TestCase
+class SetDotEnvCommandTest extends ContaoTestCase
 {
     /**
      * @var Filesystem
@@ -47,11 +47,8 @@ class SetDotEnvCommandTest extends TestCase
         parent::setUp();
 
         $this->filesystem = new Filesystem();
-        $this->tempdir = sys_get_temp_dir().'/'.uniqid('SetDotEnvCommand-', false);
+        $this->tempdir = $this->getTempDir();
         $this->tempfile = $this->tempdir.'/.env';
-
-        $this->filesystem->mkdir($this->tempdir);
-
         $this->command = new SetDotEnvCommand($this->tempdir);
     }
 
@@ -88,7 +85,6 @@ class SetDotEnvCommandTest extends TestCase
 
         $this->assertSame('', $tester->getDisplay());
         $this->assertSame(0, $tester->getStatusCode());
-
         $this->assertFileExists($this->tempfile);
         $this->assertSame("FOO='BAR'\n", file_get_contents($this->tempfile));
     }
@@ -102,7 +98,6 @@ class SetDotEnvCommandTest extends TestCase
 
         $this->assertSame('', $tester->getDisplay());
         $this->assertSame(0, $tester->getStatusCode());
-
         $this->assertFileExists($this->tempfile);
         $this->assertSame("BAR='FOO'\nFOO='BAR'\n", file_get_contents($this->tempfile));
     }
@@ -116,7 +111,6 @@ class SetDotEnvCommandTest extends TestCase
 
         $this->assertSame('', $tester->getDisplay());
         $this->assertSame(0, $tester->getStatusCode());
-
         $this->assertFileExists($this->tempfile);
         $this->assertSame("BAR='FOO'\nFOO='BAR'\n", file_get_contents($this->tempfile));
     }
@@ -128,7 +122,6 @@ class SetDotEnvCommandTest extends TestCase
 
         $this->assertSame('', $tester->getDisplay());
         $this->assertSame(0, $tester->getStatusCode());
-
         $this->assertFileExists($this->tempfile);
         $this->assertSame("FOO='UNESCAPED '\'' STRING'\n", file_get_contents($this->tempfile));
     }


### PR DESCRIPTION
This allows the Contao Manager (and other API tools) to write all environment variables. Necessary to be able to e.g. add trusted proxies (#68).

FYI, changing/removing existing commands is intended and that's what the API version is for.