### PR TITLE
[RTM] Automatically cache assets forever

### DIFF
--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -5,6 +5,16 @@
     </FilesMatch>
 </IfModule>
 
+# Automatically add caching headers for 1 year on assets residing
+# in assets/images which are all thumbnails that contain a hash
+# in their respective filenames.
+<IfModule mod_headers.c>
+  <IfModule mod_rewrite.c>
+    RewriteRule ^assets/images/.+$ - [ENV=CONTAO_THUMBNAILS:true]
+    Header set Cache-Control "max-age=31536000" env=CONTAO_THUMBNAILS
+  </IfModule>
+</IfModule>
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
 

--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -6,11 +6,11 @@
         # in /assets as well as /bundles which are all assets that contain a hash
         # in their respective filenames or are called using some ?version parameter
         # for cache busting.
-        RewriteRule ^(assets|bundles)/.+$ - [ENV=CONTAO_ASSETS:true]
+        RewriteRule ^(assets|bundles)/ - [ENV=CONTAO_ASSETS:true]
         Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
 
         # Allow CORS on any tinymce4 skins
-        RewriteRule ^assets/tinymce4/js/skins.+$ - [ENV=CONTAO_TINYMCE_SKINS:true]
+        RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKINS:true]
         Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKINS
     </IfModule>
 

--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -1,14 +1,15 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
-    # Automatically add caching for 1 year on assets residing
-    # in /assets as well as /bundles which are all assets that contain a hash
-    # in their respective filenames or are called using some ?version parameter
-    # for cache busting.
     <IfModule mod_headers.c>
+        # Automatically add caching for 1 year on assets residing
+        # in /assets as well as /bundles which are all assets that contain a hash
+        # in their respective filenames or are called using some ?version parameter
+        # for cache busting.
         RewriteRule ^(assets|bundles)/.+$ - [ENV=CONTAO_ASSETS:true]
         Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
 
+        # Allow CORS on any tinymce4 skins
         RewriteRule ^assets/tinymce4/js/skins.+$ - [ENV=CONTAO_TINYMCE_SKINS:true]
         Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKINS
     </IfModule>

--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -1,10 +1,3 @@
-<IfModule mod_headers.c>
-    # Allow access from all domains for webfonts (see contao/core-bundle#528)
-    <FilesMatch "\.(ttf|ttc|otf|eot|woff2?|font\.css)$">
-        Header set Access-Control-Allow-Origin "*"
-    </FilesMatch>
-</IfModule>
-
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
@@ -15,6 +8,9 @@
     <IfModule mod_headers.c>
         RewriteRule ^(assets|bundles)/.+$ - [ENV=CONTAO_ASSETS:true]
         Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
+
+        RewriteRule ^assets/tinymce4/js/skins.+$ - [ENV=CONTAO_TINYMCE_SKINS:true]
+        Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKINS
     </IfModule>
 
     # Determine the RewriteBase automatically and set it as environment variable.

--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -2,14 +2,12 @@
     RewriteEngine On
 
     <IfModule mod_headers.c>
-        # Automatically add caching for 1 year on assets residing
-        # in /assets as well as /bundles which are all assets that contain a hash
-        # in their respective filenames or are called using some ?version parameter
-        # for cache busting.
+        # Assets in /assets and /bundles either contain a hash in their filename
+        # or are called with a ?version suffix, therefore cache them for 1 year.
         RewriteRule ^(assets|bundles)/ - [ENV=CONTAO_ASSETS:true]
         Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
 
-        # Allow CORS on any tinymce4 skins
+        # Allow CORS on The Contao TinyMCE skin.
         RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKIN:true]
         Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKIN
     </IfModule>

--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -7,7 +7,7 @@
         RewriteRule ^(assets|bundles)/ - [ENV=CONTAO_ASSETS:true]
         Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
 
-        # Allow CORS on The Contao TinyMCE skin.
+        # Allow CORS on the Contao TinyMCE skin.
         RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKIN:true]
         Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKIN
     </IfModule>

--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -9,8 +9,9 @@
     RewriteEngine On
 
     # Automatically add caching for 1 year on assets residing
-    # in /assets as well as /bundles which are all thumbnails that contain a hash
-    # in their respective filenames.
+    # in /assets as well as /bundles which are all assets that contain a hash
+    # in their respective filenames or are called using some ?version parameter
+    # for cache busting.
     <IfModule mod_headers.c>
         RewriteRule ^(assets|bundles)/.+$ - [ENV=CONTAO_ASSETS:true]
         Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS

--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -5,18 +5,16 @@
     </FilesMatch>
 </IfModule>
 
-# Automatically add caching headers for 1 year on assets residing
-# in assets/images which are all thumbnails that contain a hash
-# in their respective filenames.
-<IfModule mod_headers.c>
-  <IfModule mod_rewrite.c>
-    RewriteRule ^assets/images/.+$ - [ENV=CONTAO_THUMBNAILS:true]
-    Header set Cache-Control "max-age=31536000" env=CONTAO_THUMBNAILS
-  </IfModule>
-</IfModule>
-
 <IfModule mod_rewrite.c>
     RewriteEngine On
+
+    # Automatically add caching for 1 year on assets residing
+    # in /assets as well as /bundles which are all thumbnails that contain a hash
+    # in their respective filenames.
+    <IfModule mod_headers.c>
+        RewriteRule ^(assets|bundles)/.+$ - [ENV=CONTAO_ASSETS:true]
+        Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
+    </IfModule>
 
     # Determine the RewriteBase automatically and set it as environment variable.
     # If you are using Apache aliases to do mass virtual hosting or installed the

--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -10,8 +10,8 @@
         Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
 
         # Allow CORS on any tinymce4 skins
-        RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKINS:true]
-        Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKINS
+        RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKIN:true]
+        Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKIN
     </IfModule>
 
     # Determine the RewriteBase automatically and set it as environment variable.


### PR DESCRIPTION
All our thumbnails contain hashes so the files can be cached forever by the clients as in case it is updated, the path will change.
I think it would be a great addition to automatically add the caching headers so everything inside `assets/images` is cached forever (aka 1 year).