### PR TITLE
[RTM] Added the CleanupTagsListener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "contao/installation-bundle": "self.version",
         "contao/manager-plugin": "^2.4",
         "doctrine/doctrine-bundle": "^1.6",
+        "friendsofsymfony/http-cache": "^2.4",
         "friendsofsymfony/http-cache-bundle": "^2.3",
         "lexik/maintenance-bundle": "^2.1.3",
         "nelmio/security-bundle": "^2.2",

--- a/src/HttpKernel/ContaoCache.php
+++ b/src/HttpKernel/ContaoCache.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 namespace Contao\ManagerBundle\HttpKernel;
 
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
+use FOS\HttpCache\SymfonyCache\CleanupCacheTagsListener;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
+use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,6 +35,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
         $this->addSubscriber(new PurgeListener());
         $this->addSubscriber(new PurgeTagsListener());
         $this->addSubscriber(new HeaderReplaySubscriber(['ignore_cookies' => ['/^csrf_./']]));
+        $this->addSubscriber(new CleanupCacheTagsListener());
 
         $kernel->setHttpCache($this);
     }
@@ -52,7 +55,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     {
         return new Psr6Store([
             'cache_directory' => $this->cacheDir ?: $this->kernel->getCacheDir().'/http_cache',
-            'cache_tags_header' => 'X-Cache-Tags',
+            'cache_tags_header' => TagHeaderFormatter::DEFAULT_HEADER_NAME,
         ]);
     }
 }

--- a/tests/HttpKernel/ContaoCacheTest.php
+++ b/tests/HttpKernel/ContaoCacheTest.php
@@ -15,6 +15,7 @@ namespace Contao\ManagerBundle\Tests\HttpKernel;
 use Contao\ManagerBundle\HttpKernel\ContaoCache;
 use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Contao\TestCase\ContaoTestCase;
+use FOS\HttpCache\SymfonyCache\CleanupCacheTagsListener;
 use FOS\HttpCache\SymfonyCache\Events;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
@@ -59,6 +60,9 @@ class ContaoCacheTest extends ContaoTestCase
         $preInvalidateListeners = $dispatcher->getListeners(Events::PRE_INVALIDATE);
         $this->assertInstanceOf(PurgeListener::class, $preInvalidateListeners[0][0]);
         $this->assertInstanceOf(PurgeTagsListener::class, $preInvalidateListeners[1][0]);
+
+        $postHandleListeners = $dispatcher->getListeners(Events::POST_HANDLE);
+        $this->assertInstanceOf(CleanupCacheTagsListener::class, $postHandleListeners[0][0]);
     }
 
     public function testCreatesTheCacheStore(): void


### PR DESCRIPTION
This is the PR that removes the cache tags headers from the final response. Once the FOSHttpCache lib is released, the tests need to be triggered again (so Composer can find the version) and then it should be ready to merge.