### PR TITLE
Update .htaccess

### DIFF
--- a/src/Resources/skeleton/web/.htaccess
+++ b/src/Resources/skeleton/web/.htaccess
@@ -1,3 +1,22 @@
+# Use the front controller as index file. It serves as a fallback solution when
+# every other rewrite/redirect fails (e.g. in an aliased environment without
+# mod_rewrite). Additionally, this reduces the matching process for the
+# start page (path "/") because otherwise Apache will apply the rewriting rules
+# to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
+DirectoryIndex index.php
+
+# By default, Apache does not evaluate symbolic links if you did not enable this
+# feature in your server configuration. Uncomment the following line if you
+# install assets as symlinks or if you experience problems related to symlinks
+# when compiling LESS/Sass/CoffeScript assets.
+# Options FollowSymlinks
+
+# Disabling MultiViews prevents unwanted negotiation, e.g. "/index" should not resolve
+# to the front controller "/index.php" but be rewritten to "/index.php/index".
+<IfModule mod_negotiation.c>
+    Options -MultiViews
+</IfModule>
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
@@ -54,7 +73,7 @@
         # When mod_rewrite is not available, we instruct a temporary redirect of
         # the start page to the front controller explicitly so that the website
         # and the generated links can still be used.
-        RedirectMatch 302 ^/$ /index.php/
+        RedirectMatch 307 ^/$ /index.php/
         # RedirectTemp cannot be used instead
     </IfModule>
 </IfModule>


### PR DESCRIPTION
This updates the .htaccess with the current version of Symfony's apache-pack recipe: https://github.com/symfony/recipes-contrib/blob/master/symfony/apache-pack/1.0/public/.htaccess

However, as mentioned in https://github.com/contao/core-bundle/issues/1699, I was wondering if we should remove any fallbacks when `mod_rewrite` is not available, since any images will not work this way any more since Contao 4.8 due to the deferred image creation mechanic.

Or, alternatively, the Contao Manager could introduce a check, if URLs are properly rewritten to `index.php`?