### PR TITLE
Avoid error if the DATABASE_URL environment variable is an empty string

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -510,7 +510,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         }
 
         // If URL is set, it overrides the driver option
-        if (null !== $url) {
+        if (!empty($url)) {
             $driver = str_replace('-', '_', parse_url($url, PHP_URL_SCHEME));
         }
 


### PR DESCRIPTION
I think there might be a problem in `contao/manager-bundle`: https://github.com/contao/manager-bundle/blob/5.x/src/ContaoManager/Plugin.php#L514

If the `.env` file contains the empty `DATABASE_URL` value, which could be the case when it is committed to the git repository; for example:

```env
DATABASE_URL=
```

… and there is no `.env.local` file (in my case in CI/CD Github Action) then I do get an error upon `composer install` (or speaking precisely upon `@php vendor/bin/contao-setup`):

```
PHP Fatal error:  Uncaught TypeError: str_replace(): Argument #3 ($subject) must be of type array|string, null given in /home/runner/work/my_vendor/my_project/vendor/contao/manager-bundle/src/ContaoManager/Plugin.php:511
```

The reason is that `parse_url($url, PHP_URL_SCHEME)` returns `null` if the `$url` is an empty string.

I find it quite common to have the `.env` file in the repository with an empty `DATABASE_URL` value, and it should not interrupt the fundamental command such as `composer install`. Thus my proposal to check if `$url` is an empty value, or not.